### PR TITLE
Fixes Blog/Blob typo

### DIFF
--- a/articles/active-directory/develop/scenario-web-app-call-api-app-configuration.md
+++ b/articles/active-directory/develop/scenario-web-app-call-api-app-configuration.md
@@ -181,7 +181,7 @@ private async Task OnAuthorizationCodeReceived(AuthorizationCodeReceivedNotifica
 
 ### MSAL.NET Token cache for a ASP.NET (Core) Web app
 
-In web apps (or web APIs as a matter of fact), the token cache implementation is different from the Desktop applications token cache implementations (which are often [file based](scenario-desktop-acquire-token.md#file-based-token-cache). It can use the ASP.NET/ASP.NET Core session, or a Redis cache, or a database, or even Azure Blog storage. In the code snippet above this is the object of the `EnablePersistence(HttpContext, clientApp.UserTokenCache, clientApp.AppTokenCache);` method call, which binds a cache service. The detail of what happens here is beyond the scope of this scenario guide, but links are provided below.
+In web apps (or web APIs as a matter of fact), the token cache implementation is different from the Desktop applications token cache implementations (which are often [file based](scenario-desktop-acquire-token.md#file-based-token-cache). It can use the ASP.NET/ASP.NET Core session, or a Redis cache, or a database, or even Azure Blob storage. In the code snippet above this is the object of the `EnablePersistence(HttpContext, clientApp.UserTokenCache, clientApp.AppTokenCache);` method call, which binds a cache service. The detail of what happens here is beyond the scope of this scenario guide, but links are provided below.
 
 > [!IMPORTANT]
 > A very important thing to realize is that for web Apps and web APIs, there should be one token cache per user (per account). You need to serialize the token cache for each account.


### PR DESCRIPTION
A very minor tweak, but the presumption is that Azure Blob storage is what was meant.